### PR TITLE
Add checked Patch support

### DIFF
--- a/bin/gen-idm-ts-types.js
+++ b/bin/gen-idm-ts-types.js
@@ -173,9 +173,11 @@ function generateConnectorTypes(idmConfigDir, subConnectorTypes) {
       // Resolve the path preferring the current working directory
       connectorObject = require(path.resolve(conn));
     } catch (err) {
-      var newErr = Error("Failed to load connector file [" + conn + "]");
-      newErr.stack += "\nCaused by: " + err.stack;
-      throw newErr;
+      if (err instanceof Error) {
+        var newErr = Error("Failed to load connector file [" + conn + "]");
+        newErr.stack += "\nCaused by: " + err.stack;
+        throw newErr;
+      } 
     }
 
     const match = provisionerRegex.exec(conn);
@@ -231,9 +233,11 @@ function generateManagedTypes(idmConfigDir, subManagedTypes) {
     // Resolve the path preferring the current working directory
     managedObjects = require(path.resolve(managedObjectsFile));
   } catch (err) {
-    var newErr = Error("Failed to load managed objects file [" + managedObjectsFile + "]");
-    newErr.stack += "\nCaused by: " + err.stack;
-    throw newErr;
+    if (err instanceof Error) {
+      var newErr = Error("Failed to load managed objects file [" + managedObjectsFile + "]");
+      newErr.stack += "\nCaused by: " + err.stack;
+      throw newErr;
+    }
   }
   const idmTypes = managedObjects.objects.sort(compareName).map(mo => {
     const managedTypeName = generateManagedTypeName(mo.name);

--- a/lib/idm-globals.d.ts
+++ b/lib/idm-globals.d.ts
@@ -18,12 +18,22 @@ interface HashedValue {}
 
 type HashAlgorithm = "SHA-256" | "SHA-384" | "SHA-512" | "Bcrypt" | "Scrypt" | "PBKDF2";
 
-type PatchOperation = "add" | "remove" | "replace" | "increment";
+type PatchRemoveOperation = "remove"
+type PatchValueOperation = "add" | "replace" | "increment" | "transform";
+type PatchFromOperation = "copy" | "move";
+type PatchOperation = PatchValueOperation | PatchRemoveOperation | PatchFromOperation;
 
 type PatchOpts = {
-  operation: PatchOperation;
+  operation: PatchValueOperation;
   field: string;
   value: any;
+} | {
+  operation: PatchRemoveOperation;
+  field: string;
+} | {
+  operation: PatchFromOperation;
+  from: string;
+  field: string;
 };
 
 type Action = "CREATE" | "UPDATE" | "DELETE" | "LINK" | "UNLINK" | "EXCEPTION" | "IGNORE" | "REPORT" | "NOREPORT" | "ASYNC";

--- a/lib/idm-globals.d.ts
+++ b/lib/idm-globals.d.ts
@@ -38,7 +38,7 @@ type PatchOpts = {
 };
 
 /**
- * These are the valid actions available to a particulation situation during synchronization.
+ * These are the valid actions available to a particular situation during synchronization.
  *
  * @see https://backstage.forgerock.com/docs/idm/7.1/synchronization-guide/sync-actions.html#sync-actions
  */

--- a/lib/idm-globals.d.ts
+++ b/lib/idm-globals.d.ts
@@ -57,7 +57,7 @@ interface OpenIDM {
   isEncrypted: (value: any) => value is EncryptedValue;
   hash: (value: any, algorithm?: HashAlgorithm) => HashedValue;
   isHashed: (value: any) => value is HashedValue;
-  matches: (string: HashedValue, value: any) => boolean;
+  matches: (string: string, value: HashedValue) => boolean;
 }
 
 type Cookie = {};

--- a/lib/idm-globals.d.ts
+++ b/lib/idm-globals.d.ts
@@ -30,6 +30,7 @@ type PatchOpts = {
 } | {
   operation: PatchRemoveOperation;
   field: string;
+  value?: any;
 } | {
   operation: PatchFromOperation;
   from: string;

--- a/lib/idm-globals.d.ts
+++ b/lib/idm-globals.d.ts
@@ -37,6 +37,11 @@ type PatchOpts = {
   field: string;
 };
 
+/**
+ * These are the valid actions available to a particulation situation during synchronization.
+ *
+ * @see https://backstage.forgerock.com/docs/idm/7.1/synchronization-guide/sync-actions.html#sync-actions
+ */
 type Action = "CREATE" | "UPDATE" | "DELETE" | "LINK" | "UNLINK" | "EXCEPTION" | "IGNORE" | "REPORT" | "NOREPORT" | "ASYNC";
 
 interface OpenIDM {

--- a/lib/idm-ts.ts
+++ b/lib/idm-ts.ts
@@ -11,6 +11,26 @@ type ResultType<T extends IDMObjectType<string>, FieldTypes extends keyof T> = P
 type QueryFilterTypesafeParams<T extends IDMObjectType<string>> = { filter: Filter<T> };
 type QueryFilterExtended<T extends IDMObjectType<string>> = QueryFilter | (QueryFilterTypesafeParams<T> & QueryOpts);
 
+export type CheckedPatchOpts<T> = {
+  operation: PatchValueOperation;
+  field: Fields<T>;
+  value: any;
+} | {
+  operation: PatchRemoveOperation;
+  field: Fields<T>;
+  value?: any;
+} | {
+  operation: PatchFromOperation;
+  from: string;
+  field: Fields<T>;
+};
+
+type CombinedPatchOpts<T> = { 
+  readonly checkedPatches?: CheckedPatchOpts<T>[];
+  readonly unCheckedPatches: PatchOpts[];
+}
+type CompositePatchOpts<T> = CheckedPatchOpts<T>[] | CombinedPatchOpts<T>
+
 export type WithOptionalId<A extends { _id: string }> = Omit<A, "_id"> & {
   _id?: string;
 };
@@ -60,23 +80,29 @@ export class IDMObject<T extends IDMObjectType<string>, D extends IDMObjectType<
   public patch<F extends Fields<T>>(
     id: string,
     rev: string | null,
-    value: PatchOpts[],
+    value: CompositePatchOpts<T>,
     options: { readonly params?: object; readonly fields: F[] }
   ): ResultType<T, F>;
   public patch<F extends Fields<T>>(
     id: string,
     rev: string | null,
-    value: PatchOpts[],
+    value: CompositePatchOpts<T>,
     options: { readonly params?: object; readonly unCheckedFields: F[] }
   ): T & Revision;
-  public patch<F extends Fields<T>>(id: string, rev: string | null, value: PatchOpts[], options?: { readonly params?: object }): D & Revision;
+  public patch<F extends Fields<T>>(id: string, rev: string | null, value: CompositePatchOpts<T>, options?: { readonly params?: object }): D & Revision;
   public patch<F extends Fields<T>>(
     id: string,
     rev: string | null,
-    value: PatchOpts[],
+    value: CompositePatchOpts<T>,
     { params, fields, unCheckedFields }: { readonly params?: object; readonly fields?: F[]; readonly unCheckedFields?: string[] } = {}
   ) {
-    return openidm.patch(`${this.type}/${id}`, rev, value, params, unCheckedFields ? unCheckedFields : fields);
+    let patchValues: PatchOpts[];
+    if (this.isCombinedPatchOpts(value)){
+      patchValues = [...value.unCheckedPatches, ...value.checkedPatches ?? []]
+    } else {
+      patchValues = value
+    }
+    return openidm.patch(`${this.type}/${id}`, rev, patchValues, params, unCheckedFields ? unCheckedFields : fields);
   }
 
   public update<F extends Fields<T>>(
@@ -154,6 +180,10 @@ export class IDMObject<T extends IDMObjectType<string>, D extends IDMObjectType<
     } else {
       return params;
     }
+  }
+
+  private isCombinedPatchOpts(value: CompositePatchOpts<T>): value is CombinedPatchOpts<T> {
+    return (value as CombinedPatchOpts<T>)?.unCheckedPatches !== undefined
   }
 }
 

--- a/lib/idm-ts.ts
+++ b/lib/idm-ts.ts
@@ -96,12 +96,9 @@ export class IDMObject<T extends IDMObjectType<string>, D extends IDMObjectType<
     value: CompositePatchOpts<T>,
     { params, fields, unCheckedFields }: { readonly params?: object; readonly fields?: F[]; readonly unCheckedFields?: string[] } = {}
   ) {
-    let patchValues: PatchOpts[];
-    if (this.isCombinedPatchOpts(value)){
-      patchValues = [...value.unCheckedPatches, ...value.checkedPatches ?? []]
-    } else {
-      patchValues = value
-    }
+    const patchValues = this.isCombinedPatchOpts(value)
+      ? [...value.unCheckedPatches, ...value.checkedPatches ?? []]
+      : value;
     return openidm.patch(`${this.type}/${id}`, rev, patchValues, params, unCheckedFields ? unCheckedFields : fields);
   }
 

--- a/lib/query-filter.ts
+++ b/lib/query-filter.ts
@@ -98,7 +98,7 @@ export const anyOf = <A>(...dsl: Filter<A>[]): Filter<A> => dsl.reduce((p, c) =>
 // this returns true if any are true.
 export const oneOf = <A, K extends keyof A>(field: keyof A, ...vals: A[K][]): Filter<A> => anyOf(...vals.map(x => equals(field, x)));
 
-const escapeQuotes = (str: string): string => str.replace("'", "\\'");
+const escapeQuotes = (str: string): string => str.replace(/'/g, "\\'");
 const prepareValue = (val: unknown): string => {
   if (typeof val === "string") {
     return `'${escapeQuotes(val ?? "")}'`;

--- a/lib/query-filter.ts
+++ b/lib/query-filter.ts
@@ -117,13 +117,13 @@ export const interpretToFilter = <A>(dsl: Filter<A>): string => {
     case Kind.Contains:
     case Kind.StartsWith:
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      return `/${dsl.field} ${dsl.kind} ${prepareValue(dsl.val)}`;
+      return `/${dsl.field.toString()} ${dsl.kind} ${prepareValue(dsl.val)}`;
     case Kind.And:
     case Kind.Or:
       return `(${interpretToFilter(dsl.a)} ${dsl.kind} ${interpretToFilter(dsl.b)})`;
     case Kind.Presence:
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      return `/${dsl.field} ${dsl.kind}`;
+      return `/${dsl.field.toString()} ${dsl.kind}`;
     case Kind.Not:
       return `${dsl.kind}(${interpretToFilter(dsl.filter)})`;
     case Kind.True:

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "tslint-immutable": "^6.0.1",
     "tslint-sonarts": "^1.9.0",
     "type-coverage": "^2.1.0",
-    "typescript": "^3.9.4"
+    "typescript": "^4.7.3"
   },
   "scripts": {
     "type-check": "tsc --noEmit",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3783,9 +3783,9 @@ supports-hyperlinks@^2.1.0:
     supports-color "^7.0.0"
 
 tar@^6.0.2, tar@^6.1.0:
-  version "6.1.3"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.3.tgz#e44b97ee7d6cc7a4c574e8b01174614538291825"
-  integrity sha512-3rUqwucgVZXTeyJyL2jqtUau8/8r54SioM1xj3AmTX3HnWQdj2AydfJ2qYYayPyIIznSplcvU9mhBb7dR2XF3w==
+  version "6.1.11"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
+  integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
   dependencies:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3484,9 +3484,9 @@ semver-diff@^3.1.1:
     semver "^6.3.0"
 
 semver-regex@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-3.1.2.tgz#34b4c0d361eef262e07199dbef316d0f2ab11807"
-  integrity sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA==
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-3.1.3.tgz#b2bcc6f97f63269f286994e297e229b6245d0dc3"
+  integrity sha512-Aqi54Mk9uYTjVexLnR67rTyBusmwd04cLkHy9hNvk3+G3nT2Oyg7E0l4XVbOaNwIvQ3hHeYxGcyEy+mKreyBFQ==
 
 "semver@2 || 3 || 4 || 5", semver@^5.3.0:
   version "5.7.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4014,10 +4014,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^3.9.4:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+typescript@^4.7.3:
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.3.tgz#8364b502d5257b540f9de4c40be84c98e23a129d"
+  integrity sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==
 
 uglify-js@^3.1.4:
   version "3.13.10"


### PR DESCRIPTION
This allows for checking field names against managed/system object fields

The default behaviour is now checked when using the array syntax:

```typescript
idm.managed.user.patch(newObject._id, null, [{ field: "password", operation: "remove" }])
```

If a field is renamed or typo'd, then it would fail to compile, eg:
```typescript
idm.managed.user.patch(newObject._id, null, [{ field: "password1", operation: "remove" }])
```

There is also an alternate syntax that offers an escape hatch for more complicated field syntax.

eg:

Using an escape hatch:

```typescript
idm.managed.user.patch(newObject._id, null, {
  unCheckedPatches: [{ field: "/roles/-", operation: "remove", value: "foo" }],
})
```

Combining checked and unchecked is also possible:

```typescript
idm.managed.user.patch(newObject._id, null, {
  checkedPatches: [{ field: "password", operation: "remove" }],
  unCheckedPatches: [{ field: "/roles/-", operation: "remove", value: "foo" }],
})
```

Additional support extra patch operations was also added.