### PR TITLE
fix: Correct returnByDefault behaviour

### DIFF
--- a/bin/gen-idm-ts-types.js
+++ b/bin/gen-idm-ts-types.js
@@ -128,7 +128,7 @@ function convertType(props, propName, originalObjectName, tsTypeName, subTypes) 
 }
 
 function calcReturnByDefault(prop) {
-  if (prop.returnByDefault) {
+  if (prop.returnByDefault !== undefined) {
     return prop.returnByDefault;
   } else {
     if (prop.type === "relationship") {


### PR DESCRIPTION
* When returnByDefault was false, it would be ignored, and it would fallback to default behaviour. This fix correctly checks if the returnByDefault property exists, instead of if the value is truthy.