### PR TITLE
fix: allow backslash as path separator for Windows

### DIFF
--- a/bin/gen-idm-ts-types.js
+++ b/bin/gen-idm-ts-types.js
@@ -63,7 +63,7 @@ const isManagedType = typeName => typeName.startsWith("Managed");
 
 const filterResourceCollection = resourceCollection => resourceCollection.filter(res => res.path.startsWith("managed/"));
 
-const provisionerRegex = /\.*\/provisioner.openicf-(.*)\.json.*/;
+const provisionerRegex = /\.*[\\\/]provisioner.openicf-(.*)\.json.*/;
 
 function convertType(props, propName, originalObjectName, tsTypeName, subTypes) {
   var type;


### PR DESCRIPTION
Just a small fix, which seem sufficient to get the type generator working on Windows.

I've found this project very useful, thanks for maintaining it :+1: